### PR TITLE
Added the ability to use the juice.juiceResources method to pull in linked web resources

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,9 @@ module.exports = function(options) {
 		var self = this;
 
 		var onJuiceComplete = function(err, html) {
-			if(err) {
-				throw new Exception(err);
+			if(!err) {
+				file.contents = new Buffer(html);
 			}
-			file.contents = new Buffer(html);
 			self.push(file);
 			callback();
 		}


### PR DESCRIPTION
I came across your module earlier in the week, ended up needing to use juice.juiceResources() as juice() does not do this, and it's annoyingly a separate method instead of an options flag.

This patch adds the ability to specify options.includeResources = true, and it will use the juice.juiceResources method, otherwise it will use the juice() method as before.
